### PR TITLE
Remove expired certificates

### DIFF
--- a/bin/letsencrypt.sh
+++ b/bin/letsencrypt.sh
@@ -38,9 +38,26 @@ if ! [ -s ${domain}.crt ] || ! openssl x509 -checkend 2592000 -noout -in ${domai
     echo "Creating certificate for ${domain}"
   fi
 
-  python /usr/local/letsencrypt/acme-tiny/acme_tiny.py --account-key account.key --csr ${domain}.csr --acme-dir /srv/.well-known/acme-challenge/ >${domain}.crt
+  if openssl x509 -noout -checkend 0 -in ${domain}.crt; then
+    python /usr/local/letsencrypt/acme-tiny/acme_tiny.py \
+      --account-key account.key \
+      --csr ${domain}.csr \
+      --acme-dir /srv/.well-known/acme-challenge/ > ${domain}.crt \ 
+      || echo "Error creating/renewing certificate for ${domain}"
+      
+    /usr/local/letsencrypt/bin/insert-certificate.sh \
+      -h $domain \
+      -c ${domain}.crt \
+      -k ${domain}.key \
+      -t ${token} \
+      -p ${project} \
+      -r ${routes}
+      
+  else
+    echo "Removing expired certificate for ${domain}"
+    rm ${domain}.crt
+  fi
+   
 else
   echo "We already have a certificate for ${domain} which is still valid for at least 30 days."
 fi
-
-/usr/local/letsencrypt/bin/insert-certificate.sh -h $domain -c ${domain}.crt -k ${domain}.key -t ${token} -p ${project} -r ${routes}


### PR DESCRIPTION
- Remove certificates that have expired 
(renewals for the past 30 days have failed because maybe domain expired or moved elsewhere)
- Insert the certificate only if things change