### PR TITLE
Also log to stdout from the HTTP Handler

### DIFF
--- a/letsencrypt.go
+++ b/letsencrypt.go
@@ -11,13 +11,13 @@ import (
 )
 
 func renew(renewCronExpr *cronexpr.Expression) {
-  
+
   for {
     now := time.Now()
     next := renewCronExpr.Next(now)
     fmt.Printf("Next certificate renewal run at %v\n", next)
     time.Sleep(next.Sub(now))
-    
+
     certs, _ := filepath.Glob("/var/lib/letsencrypt/*.crt")
     for _, cert := range certs {
       domain :=  strings.TrimSuffix(filepath.Base(cert), filepath.Ext(cert))
@@ -30,10 +30,11 @@ func renew(renewCronExpr *cronexpr.Expression) {
 func handler(w http.ResponseWriter, r *http.Request) {
   if r.Header["Authorization"] != nil {
     proc := sh("/usr/local/letsencrypt/bin/letsencrypt.sh '%s' '%s' 2>&1", strings.Split(r.URL.Path, "/")[1], strings.Split(r.Header["Authorization"][0], " ")[1])
-    fmt.Fprintln(w,proc.stderr + proc.stdout)    
+    fmt.Fprintln(w,proc.stderr + proc.stdout)
+    fmt.Println(proc.stderr + proc.stdout)    
   } else {
     w.WriteHeader(http.StatusForbidden)
-  }  
+  }
 }
 
 func main() {
@@ -46,7 +47,7 @@ func main() {
   if renewCronExpr.Next(time.Now()).IsZero() {
     panic("Cron expression doesn't match any future dates!")
   }
- 
+
   go renew(renewCronExpr)
 
 //  now := time.Now()


### PR DESCRIPTION
It seems the Cron Renew does write to stdout while the HTTP Response Handler only writes into the HTTP Response (to get the output back in the Browser). But with this, you don't see Error Messages (like too many certificates already issued) in your OpenShift Logs. It would be nice, to also log to stdout.

Here's my Solution, just added a second fmt print to also log to stdout. Beaware, I have no experience with go and cannot really test this. So, you might wanna check&test it :)